### PR TITLE
Hardcoded the excel engine

### DIFF
--- a/pandablob/pandablob.py
+++ b/pandablob/pandablob.py
@@ -29,8 +29,12 @@ def df_to_blob(
         if extension == ".json":
             df.to_json(string_io, **pandas_kwargs)
         return blob_client.upload_blob(string_io.getvalue(), overwrite=overwrite)
-    if extension == ".xlsx" or extension == ".xls":
+    if extension in [".xls", ".xlsx"]:
         bytes_io = io.BytesIO()
+        if extension == ".xls":
+            pandas_kwargs.update({"engine": "xlrd"})
+        else:
+            pandas_kwargs.update({"engine": "openpyxl"})
         df.to_excel(bytes_io, **pandas_kwargs)
         return blob_client.upload_blob(bytes_io.getvalue(), overwrite=overwrite)
 

--- a/pandablob/pandablob.py
+++ b/pandablob/pandablob.py
@@ -31,10 +31,6 @@ def df_to_blob(
         return blob_client.upload_blob(string_io.getvalue(), overwrite=overwrite)
     if extension in [".xls", ".xlsx"]:
         bytes_io = io.BytesIO()
-        if extension == ".xls":
-            pandas_kwargs.update({"engine": "xlrd"})
-        else:
-            pandas_kwargs.update({"engine": "openpyxl"})
         df.to_excel(bytes_io, **pandas_kwargs)
         return blob_client.upload_blob(bytes_io.getvalue(), overwrite=overwrite)
 
@@ -60,8 +56,12 @@ def blob_to_df(
     if extension == ".json":
         data_stream = io.BytesIO(blob_client.download_blob().readall())
         return pd.read_json(data_stream, **pandas_kwargs)
-    if extension == ".xlsx" or extension == ".xls":
+    if extension in [".xls", ".xlsx"]:
         data_stream = io.BytesIO(blob_client.download_blob().readall())
+        if extension == ".xls" and "engine" not in pandas_kwargs.keys():
+            pandas_kwargs.update({"engine": "xlrd"})
+        elif "engine" not in pandas_kwargs.keys():
+            pandas_kwargs.update({"engine": "openpyxl"})
         return pd.read_excel(data_stream, **pandas_kwargs)
 
     raise TypeError(f"{extension} files are not yet supported.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,8 @@ def pandas_arguments_download():
         "csv": {"delimiter": ",", "index_col": 0},
         "json": {"orient": "index"},
         "txt": {"delimiter": ",", "index_col": 0},
-        "xls": {"index_col": 0, "engine": "xlrd"},
-        "xlsx": {"index_col": 0, "engine": "openpyxl"},
+        "xls": {"index_col": 0},
+        "xlsx": {"index_col": 0},
     }
 
 
@@ -58,12 +58,9 @@ def dataframe_upload():
                 return pd.read_table(file, **arguments)
             return pd.read_table(io.StringIO(file), **arguments)
         elif file_extension in [".xls", ".xlsx"]:
-            if "engine" not in additional_kwargs.keys():
-                if file_extension == ".xls":
-                    additional_kwargs.update({"engine": "xlrd"})
-                else:
-                    additional_kwargs.update({"engine": "openpyxl"})
-            return pd.read_excel(file, index_col=0, **additional_kwargs)
+            if file_extension == ".xls":
+                return pd.read_excel(file, index_col=0, engine="xlrd", **additional_kwargs)
+            return pd.read_excel(file, index_col=0, engine="openpyxl", **additional_kwargs)
         elif file_extension == ".json":
             return pd.read_json(file, **additional_kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,9 @@ def dataframe_upload():
                 return pd.read_excel(
                     file, index_col=0, engine="xlrd", **additional_kwargs
                 )
-            return pd.read_excel(file, index_col=0, **additional_kwargs)
+            return pd.read_excel(
+                file, index_col=0, engine="openpyxl", **additional_kwargs
+            )
         elif file_extension == ".json":
             return pd.read_json(file, **additional_kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,8 @@ def pandas_arguments_download():
         "csv": {"delimiter": ",", "index_col": 0},
         "json": {"orient": "index"},
         "txt": {"delimiter": ",", "index_col": 0},
-        "xls": {"index_col": 0},
-        "xlsx": {"index_col": 0},
+        "xls": {"index_col": 0, "engine": "xlrd"},
+        "xlsx": {"index_col": 0, "engine": "openpyxl"},
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,11 @@ def dataframe_upload():
                 return pd.read_table(file, **arguments)
             return pd.read_table(io.StringIO(file), **arguments)
         elif file_extension in [".xls", ".xlsx"]:
+            if "engine" not in additional_kwargs.keys():
+                if file_extension == ".xls":
+                    additional_kwargs.update({"engine": "xlrd"})
+                else:
+                    additional_kwargs.update({"engine": "openpyxl"})
             return pd.read_excel(file, index_col=0, **additional_kwargs)
         elif file_extension == ".json":
             return pd.read_json(file, **additional_kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,9 +58,11 @@ def dataframe_upload():
                 return pd.read_table(file, **arguments)
             return pd.read_table(io.StringIO(file), **arguments)
         elif file_extension in [".xls", ".xlsx"]:
-            if file_extension == ".xls":
-                return pd.read_excel(file, index_col=0, engine="xlrd", **additional_kwargs)
-            return pd.read_excel(file, index_col=0, engine="openpyxl", **additional_kwargs)
+            if file_extension == ".xls" and not stream:
+                return pd.read_excel(
+                    file, index_col=0, engine="xlrd", **additional_kwargs
+                )
+            return pd.read_excel(file, index_col=0, **additional_kwargs)
         elif file_extension == ".json":
             return pd.read_json(file, **additional_kwargs)
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -30,6 +30,9 @@ def test_download(file, test_files, mock_download):
     if extension == ".json":
         compare_df = pd.read_json(file_location)
         assert df.equals(compare_df)
-    if extension == ".xlsx" or extension == ".xls":
-        compare_df = pd.read_excel(file_location)
+    if extension == ".xls":
+        compare_df = pd.read_excel(file_location, engine="xlrd")
+        assert df.equals(compare_df)
+    if extension == ".xlsx":
+        compare_df = pd.read_excel(file_location, engine="openpyxl")
         assert df.equals(compare_df)

--- a/tests/test_download_kwargs.py
+++ b/tests/test_download_kwargs.py
@@ -10,7 +10,7 @@ import pandablob
 
 @pytest.mark.parametrize("file", ["csv", "json", "txt", "xls", "xlsx"])
 def test_download_kwargs(mock_download, test_files, pandas_arguments_download, file):
-    """Mock uploading to the azure blob."""
+    """Mock downloading from the azure blob with additional kwargs."""
 
     # Create required input
     file_name = f"test_data.{file}"
@@ -30,6 +30,9 @@ def test_download_kwargs(mock_download, test_files, pandas_arguments_download, f
     if extension == ".json":
         compare_df = pd.read_json(file_location, orient="index")
         assert df.equals(compare_df)
-    if extension == ".xlsx" or extension == ".xls":
-        compare_df = pd.read_excel(file_location, index_col=0)
+    if extension == ".xls":
+        compare_df = pd.read_excel(file_location, index_col=0, engine="xlrd")
+        assert df.equals(compare_df)
+    if extension == ".xlsx":
+        compare_df = pd.read_excel(file_location, index_col=0, engine="openpyxl")
         assert df.equals(compare_df)

--- a/tests/test_upload_kwargs.py
+++ b/tests/test_upload_kwargs.py
@@ -9,10 +9,10 @@ import pandablob
 
 
 @pytest.mark.parametrize("file", ["csv", "json", "txt", "xls", "xlsx"])
-def test_upload(
+def test_upload_kwargs(
     file, test_files, dataframe_upload, pandas_arguments_upload, mock_upload
 ):
-    """Mock uploading to the azure blob."""
+    """Mock uploading with additional kwargs to the azure blob."""
 
     # Create required input
     file_name = f"test_data.{file}"


### PR DESCRIPTION
To prevent any errors with reading the BytesIO objects I hardcoded the excel engine. Since the updates to `xlrd`, .xlsx files are no longer supported and other Excel engines have to be used. 